### PR TITLE
Changing MoverScore implementation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Changed the backend implementation of MoverScore to use a non-IDF dict based version.
 
 ## [v0.1.4](https://github.com/danieldeutsch/repro/releases/tag/v0.1.4) - 2022-01-29
 ### Changed

--- a/models/zhao2019/Dockerfile
+++ b/models/zhao2019/Dockerfile
@@ -1,6 +1,8 @@
-FROM pure/python:3.7-cuda10.0-base
+FROM pure/python:3.8-cuda10.0-base
 
 WORKDIR /app
+
+RUN pip install Cython
 
 # Install the Python dependencies
 RUN git clone https://github.com/AIPHES/emnlp19-moverscore && \

--- a/models/zhao2019/Readme.md
+++ b/models/zhao2019/Readme.md
@@ -69,3 +69,9 @@ Not tested
 Not tested
 - [ ] Predictions exactly replicate results reported in the paper  
 Not tested
+
+## Changelog
+### v1.1
+- Switched the implementation to use the `sentence_score` function instead of the `word_mover_score` function directly.
+This now means that the IDF functionality is not implemented.
+This was changed because if you only passed 1 candidate to be scored, the IDF dict caused that to always receive a score of 1.0, and the score of one sentence depended on which other sentences were being scored at the same time.

--- a/models/zhao2019/Readme.md
+++ b/models/zhao2019/Readme.md
@@ -60,7 +60,7 @@ pytest models/zhao2019/tests
 
 ## Status
 - [x] Regression unit tests pass  
-See [here](https://github.com/danieldeutsch/repro/actions/runs/1091879442)
+See [here](https://github.com/danieldeutsch/repro/actions/runs/1843517578)
 - [ ] Correctness unit tests pass  
 None provided in the original repo.
 - [ ] Model runs on full test dataset  

--- a/models/zhao2019/src/score.py
+++ b/models/zhao2019/src/score.py
@@ -1,32 +1,36 @@
 import argparse
 import json
 import numpy as np
+from collections import defaultdict
+from typing import List
 
 from moverscore_v2 import get_idf_dict, word_mover_score
 
+# Copied from the original repository:
+# https://github.com/AIPHES/emnlp19-moverscore/blob/55e785bb3554b8f1c3e32525d97be1ee7bc23a76/examples/example.py
+# Edited to accept stopwords
+def sentence_score(hypothesis: str, references: List[str], stopwords: List[str]):
+    idf_dict_hyp = defaultdict(lambda: 1.0)
+    idf_dict_ref = defaultdict(lambda: 1.0)
+
+    hypothesis = [hypothesis] * len(references)
+
+    scores = word_mover_score(
+        references,
+        hypothesis,
+        idf_dict_ref,
+        idf_dict_hyp,
+        stop_words=stopwords,
+        n_gram=1,
+        remove_subwords=False,
+    )
+
+    sentence_score = np.mean(scores)
+
+    return sentence_score
+
 
 def main(args):
-    candidates = []
-    references_list = []
-
-    unique_candidates = set()
-    unique_references = set()
-
-    with open(args.input_file, "r") as f:
-        for line in f:
-            data = json.loads(line)
-            candidate = data["candidate"]
-            references = data["references"]
-            candidates.append(candidate)
-            references_list.append(references)
-            unique_candidates.add(candidate)
-            for reference in references:
-                unique_references.add(reference)
-
-    # Calculate the idf dicts on the unique texts
-    idf_dict_candidates = get_idf_dict(list(unique_candidates))
-    idf_dict_references = get_idf_dict(list(unique_references))
-
     # Optionally load the stopwords
     if args.use_stopwords.lower() == "true":
         with open("stopwords.txt", "r", encoding="utf-8") as f:
@@ -34,36 +38,15 @@ def main(args):
     else:
         stopwords = []
 
-    # Flatten the candidates and references to be passed through `word_mover_score` all
-    # at once for faster processing
-    flat_candidates = []
-    flat_references = []
-    for candidate, references in zip(candidates, references_list):
-        for reference in references:
-            flat_candidates.append(candidate)
-            flat_references.append(reference)
-
-    scores = word_mover_score(
-        flat_references,
-        flat_candidates,
-        idf_dict_references,
-        idf_dict_candidates,
-        stop_words=stopwords,
-        n_gram=1,
-        remove_subwords=True,
-        batch_size=args.batch_size,
-    )
-
     with open(args.output_file, "w") as out:
-        # Take the mean over the references for the candidate
-        index = 0
-        for references in references_list:
-            this_scores = []
-            for _ in references:
-                this_scores.append(scores[index])
-                index += 1
-            average_score = np.mean(this_scores)
-            out.write(json.dumps({"moverscore": average_score}) + "\n")
+        with open(args.input_file, "r") as f:
+            for line in f:
+                data = json.loads(line)
+                candidate = data["candidate"]
+                references = data["references"]
+
+                score = sentence_score(candidate, references, stopwords)
+                out.write(json.dumps({"moverscore": score}) + "\n")
 
 
 if __name__ == "__main__":

--- a/models/zhao2019/tests/fixtures/expected.json
+++ b/models/zhao2019/tests/fixtures/expected.json
@@ -2,87 +2,87 @@
   "default": {
     "micro": [
       {
-        "moverscore": 0.5374585438614209
+        "moverscore": 0.5519537643700062
       },
       {
-        "moverscore": 0.5528654291683849
+        "moverscore": 0.5702658240517838
       },
       {
-        "moverscore": 0.5584310585149199
+        "moverscore": 0.5747977302204582
       },
       {
-        "moverscore": 0.5483838328947854
+        "moverscore": 0.5662361359209
       },
       {
-        "moverscore": 0.5401417051028986
+        "moverscore": 0.5613683115463678
       },
       {
-        "moverscore": 0.5396808726640311
+        "moverscore": 0.5614178359164702
       },
       {
-        "moverscore": 0.56281337305529
+        "moverscore": 0.5888811007295938
       },
       {
-        "moverscore": 0.5653760958979458
+        "moverscore": 0.5906006260606307
       },
       {
-        "moverscore": 0.5578759611994967
+        "moverscore": 0.5725977614540374
       },
       {
-        "moverscore": 0.5694264983227191
+        "moverscore": 0.5927708989337149
       },
       {
-        "moverscore": 0.5646481847786998
+        "moverscore": 0.5861854483292473
       },
       {
-        "moverscore": 0.5528510075354691
+        "moverscore": 0.5734556930584522
       }
     ],
     "macro": {
-      "moverscore": 0.5541627135830051
+      "moverscore": 0.5742109275493053
     }
   },
   "summarization": {
     "micro": [
       {
-        "moverscore": 0.5363679808125065
+        "moverscore": 0.5432705823571925
       },
       {
-        "moverscore": 0.553204695560149
+        "moverscore": 0.5627943245205925
       },
       {
-        "moverscore": 0.5594086145883774
+        "moverscore": 0.5681693286222553
       },
       {
-        "moverscore": 0.5478360937605564
+        "moverscore": 0.5579426600181681
       },
       {
-        "moverscore": 0.540025446393662
+        "moverscore": 0.5514187327632644
       },
       {
-        "moverscore": 0.5400406779008134
+        "moverscore": 0.5511429472168278
       },
       {
-        "moverscore": 0.5630475426798369
+        "moverscore": 0.5796158551811643
       },
       {
-        "moverscore": 0.5661348139567364
+        "moverscore": 0.5816084474147277
       },
       {
-        "moverscore": 0.5565022067471125
+        "moverscore": 0.5658549198353692
       },
       {
-        "moverscore": 0.5688220284325299
+        "moverscore": 0.5838097156474874
       },
       {
-        "moverscore": 0.5642806008389394
+        "moverscore": 0.5775403162582613
       },
       {
-        "moverscore": 0.5521844453777212
+        "moverscore": 0.5657160758438957
       }
     ],
     "macro": {
-      "moverscore": 0.5539879289207451
+      "moverscore": 0.5657403254732672
     }
   }
 }

--- a/models/zhao2019/tests/models_test.py
+++ b/models/zhao2019/tests/models_test.py
@@ -60,7 +60,11 @@ class TestZhao2019Models(unittest.TestCase):
 
     @parameterized.expand(get_testing_device_parameters())
     def test_moverscore_idf_example_fix(self, device: int):
-        # Test specific examples to ensure a bug fix worked
+        # Test specific examples to ensure a fix to the code worked properly. In one
+        # version of this metric, passing in 1 example to score always resulted in
+        # a score of 1.0 because it used an IDF dictionary and each word appeared
+        # in exactly one input (the only one). With the change, the IDF dict is no
+        # longer used
         model = MoverScore(device=device)
         actual = model.predict("Hello World", ["How are you?"])
         assert_dicts_approx_equal({"moverscore": 0.5770540645865062}, actual, abs=1e-4)

--- a/models/zhao2019/tests/models_test.py
+++ b/models/zhao2019/tests/models_test.py
@@ -57,3 +57,10 @@ class TestZhao2019Models(unittest.TestCase):
 
         with self.assertRaises(Exception):
             model.predict_batch([], use_stopwords=False)
+
+    @parameterized.expand(get_testing_device_parameters())
+    def test_moverscore_idf_example_fix(self, device: int):
+        # Test specific examples to ensure a bug fix worked
+        model = MoverScore(device=device)
+        actual = model.predict("Hello World", ["How are you?"])
+        assert_dicts_approx_equal({"moverscore": 0.5770540645865062}, actual, abs=1e-4)

--- a/repro/models/zhao2019/__init__.py
+++ b/repro/models/zhao2019/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-VERSION = "1.0"
+VERSION = "1.1"
 MODEL_NAME = os.path.basename(os.path.dirname(__file__))
 DOCKERHUB_REPO = f"danieldeutsch/{MODEL_NAME}"
 DEFAULT_IMAGE = f"{DOCKERHUB_REPO}:{VERSION}"


### PR DESCRIPTION
Changes the backend implementation from calling `word_mover_score` directly to the `sentence_score` function, which removes the IDF feature. The IDF feature made it such that a text's MoverScore would be different depending on the set of other texts that were also being evaluated.