### PR TITLE
Version bump for datasets to comply with python3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     python_requires=">=3.6",
     include_package_data=True,
     install_requires=[
-        "datasets>=1.2.1",
+        "datasets>=1.16.1",
         "docker==5.0.0",
         "joblib",
         "overrides==3.1.0",


### PR DESCRIPTION
There was an issue with Python 3.10 where [sacrerouge](https://github.com/danieldeutsch/sacrerouge) would fail to run, since it depends on this repo, which in itself installs a possibly broken `datasets` package. With this version bump, it should work again. The problematic `datasets` code was fixed in [1.16.1](https://github.com/huggingface/datasets/releases/tag/1.16.1).

This would fix Sacrerouge issue 136: https://github.com/danieldeutsch/sacrerouge/issues/136

